### PR TITLE
Hotfixes for threading

### DIFF
--- a/MachineObserver/DashboardMachineObserver.cpp
+++ b/MachineObserver/DashboardMachineObserver.cpp
@@ -119,7 +119,7 @@ namespace Umati
 				std::shared_ptr<ModelOpcUa::StructureNode> p_type = m_pOpcUaTypeReader->getTypeOfNamespace(machine.TypeDefinition.Uri);
 				machineInformation.Specification = p_type->SpecifiedBrowseName.Name;
 
-				pDashClient->addDataSet(_client->client,
+                pDashClient->addDataSet(_client->client,/* FIXME FIXME */
 					{machineInformation.NamespaceURI, machine.NodeId.Id},
 					p_type,
 					Topics::Machine(p_type, static_cast<std::string>(machine.NodeId)));

--- a/OpcUaClient/OpcUaClient.hpp
+++ b/OpcUaClient/OpcUaClient.hpp
@@ -68,9 +68,7 @@ namespace Umati
 
 			std::vector<std::string> Namespaces() override;
 
-			UA_Client *client;
-
-		protected:
+        protected:
 			//FIXME override gives "marked ‘override’, but does not override" error
 			void connectionStatusChanged(UA_Int32 clientConnectionId, UA_ServerState serverStatus);// override;
 			
@@ -122,8 +120,11 @@ namespace Umati
 			std::map<open62541Cpp::UA_NodeId, open62541Cpp::UA_NodeId, UaNodeId_Compare> m_superTypes;
 		
 		private:
-			static int PlatformLayerInitialized;
-
+            static int PlatformLayerInitialized;
+        public:
+            UA_Client *client;  // Zugriff aus dem ConnectThread, dem PublisherThread
+            std::recursive_mutex m_clientMutex;
+private:
 			void on_connected();
 
 			std::vector<UA_DataValue> readValues2(const std::list<ModelOpcUa::NodeId_t> &modelNodeIds);


### PR DESCRIPTION
several threads are accessing the open62541 client - so far without
any locking. try to protect it with a recursive mutex for now.

The client should become a private member. The place were we just
hand out a pointer to the member client instance isn't protected.