### PR TITLE
feat: Handle subtypes of spec machine types

### DIFF
--- a/DashboardClient/IDashboardDataClient.hpp
+++ b/DashboardClient/IDashboardDataClient.hpp
@@ -100,6 +100,13 @@ namespace Umati
                     return ret;
                 }
 
+                inline static BrowseContext_t HasSupertype() {
+                    BrowseContext_t ret;
+                    ret.referenceTypeId = NodeId_HasSubtype;
+                    ret.browseDirection = BrowseDirection::BACKWARD;
+                    return ret;
+                }
+
                 inline static BrowseContext_t WithReference(
                     ModelOpcUa::NodeId_t referenceTypeId)
                 {

--- a/DashboardClient/NodeIdsWellKnown.hpp
+++ b/DashboardClient/NodeIdsWellKnown.hpp
@@ -14,6 +14,7 @@ namespace Umati
         const std::string ns0UriFull = "http://opcfoundation.org/UA/";
         const std::string ns0Uri = "http://opcfoundation.org/UA/"; // Omitt for node Ids?
         const ModelOpcUa::NodeId_t NodeId_HasComponent = {ns0Uri, "i=47"};
+        const ModelOpcUa::NodeId_t NodeId_HasSubtype = {ns0Uri, "i=45"};
         const ModelOpcUa::NodeId_t NodeId_HierarchicalReferences = {ns0Uri, "i=33"};
         const ModelOpcUa::NodeId_t NodeId_HasTypeDefinition = {ns0Uri, "i=40"};
         const ModelOpcUa::NodeId_t NodeId_Organizes = {ns0Uri, "i=35"};

--- a/DashboardClient/OpcUaTypeReader.cpp
+++ b/DashboardClient/OpcUaTypeReader.cpp
@@ -27,6 +27,7 @@ namespace Umati
                 m_availableObjectTypeNamespaces[el.Namespace] = el;
                 for (auto const &e: el.Types) {
                     m_identificationTypeOfTypeDefinition.insert(std::make_pair(e, el.IdentificationType));
+                    m_baseTypeLevelOfTypeDefinition.insert(std::make_pair(e, e.BaseTypeLevel));
                 }
             }
         }
@@ -384,6 +385,14 @@ namespace Umati
             }   
             return pair->second;
 		}
+
+        int OpcUaTypeReader::getBaseTypeLevel(const ModelOpcUa::NodeId_t &typeDefinition) const {
+            auto pair = m_baseTypeLevelOfTypeDefinition.find(typeDefinition);
+            if (pair == m_baseTypeLevelOfTypeDefinition.end()) {
+                return 0;
+            }
+            return pair->second;
+        }
 
     } // namespace Dashboard
 } // namespace Umati

--- a/DashboardClient/OpcUaTypeReader.hpp
+++ b/DashboardClient/OpcUaTypeReader.hpp
@@ -36,6 +36,7 @@ namespace Umati
 
             /// \todo make the following internal structures private and provide access via funcitons
             std::map<ModelOpcUa::NodeId_t, ModelOpcUa::NodeId_t> m_identificationTypeOfTypeDefinition;
+            std::map<ModelOpcUa::NodeId_t, int> m_baseTypeLevelOfTypeDefinition;
             std::map<std::string, NamespaceInformation_t> m_availableObjectTypeNamespaces;
             std::vector<std::string> m_expectedObjectTypeNamespaces;
             std::vector<std::string> m_expectedObjectTypeNames;
@@ -43,6 +44,7 @@ namespace Umati
             std::shared_ptr<std::map<std::string, ModelOpcUa::NodeId_t>> m_nameToId = std::make_shared<std::map<std::string, ModelOpcUa::NodeId_t>>();
             std::shared_ptr<ModelOpcUa::StructureNode> typeDefinitionToStructureNode(const ModelOpcUa::NodeId_t &typeDefinition) const;
             std::shared_ptr<ModelOpcUa::StructureNode> getIdentificationTypeStructureNode(const ModelOpcUa::NodeId_t &typeDefinition) const;
+            int getBaseTypeLevel(const ModelOpcUa::NodeId_t &typeDefinition) const;
             ModelOpcUa::NodeId_t getIdentificationTypeNodeId(const ModelOpcUa::NodeId_t &typeDefinition) const;
         protected:
             /// Map of <TypeName, StructureBiNode>

--- a/MachineObserver/MachineObserver.cpp
+++ b/MachineObserver/MachineObserver.cpp
@@ -170,6 +170,10 @@ namespace Umati {
                         LOG(INFO) << "Could not fix missing type definition in browse result for machine " << machine.NodeId << ' ' << ex.what();
                     }
                 }
+                if (m_pOpcUaTypeReader->getBaseTypeLevel(machine.TypeDefinition) == 1) {
+                    auto realTypeDefinition = m_pDataClient->Browse(machine.TypeDefinition, Dashboard::IDashboardDataClient::BrowseContext_t::HasSupertype()).front().NodeId;
+                    machine.TypeDefinition = realTypeDefinition;
+                }
 				try {
 					auto typeDefinitionNodeId = m_pOpcUaTypeReader->getIdentificationTypeNodeId(machine.TypeDefinition);
 					auto ident = m_pDataClient->BrowseWithResultTypeFilter(machine.NodeId, Dashboard::IDashboardDataClient::BrowseContext_t::Hierarchical(),

--- a/Util/Configuration.hpp
+++ b/Util/Configuration.hpp
@@ -33,13 +33,17 @@ namespace Umati {
 			std::uint8_t Security = 1;
 		};
 
+        struct TypeDefinitionConfig : ModelOpcUa::NodeId_t {
+            int BaseTypeLevel = 0;
+        };
+
 		/**
 		 * @brief NamespaceInformation
 		 * Describes how to handle types introduced by a namespace.
 		 */
 		struct NamespaceInformation {
 			std::string Namespace; /**< Namespace, e.g. https://opcfoundation.org/SurfaceTechnology */
-			std::vector<ModelOpcUa::NodeId_t> Types; /**< Types, this Namespace introduces */ 
+			std::vector<TypeDefinitionConfig> Types; /**< Types, this Namespace introduces */
 			ModelOpcUa::NodeId_t IdentificationType; /**< IdentificationType, child of types */
 		};
 

--- a/Util/ConfigurationJsonFile.hpp
+++ b/Util/ConfigurationJsonFile.hpp
@@ -17,6 +17,7 @@ namespace ModelOpcUa
 }
 namespace Umati {
 	namespace Util {
+        NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TypeDefinitionConfig, Uri, Id, BaseTypeLevel);
 		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MqttConfig, Hostname, Port, Username, Password);
 		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(OpcUaConfig, Endpoint, Username, Password, Security);
 		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(NamespaceInformation, Namespace, Types, IdentificationType);

--- a/configuration.json.example
+++ b/configuration.json.example
@@ -14,15 +14,73 @@
     "http://opcfoundation.org/UA/SurfaceTechnology/Example/MaterialSupplyRoom/",
     "http://opcfoundation.org/UA/SurfaceTechnology/Example/DosingSystem/",
     "http://opcfoundation.org/UA/SurfaceTechnology/Example/OvenBooth/",
-    "http://opcfoundation.org/UA/SurfaceTechnology/Example/Pretreatment"
+    "http://opcfoundation.org/UA/SurfaceTechnology/Example/Pretreatment",
+    "http://opcfoundation.org/UA/Woodworking/",
+    "http://opcfoundation.org/UA/Robotics/",
+    "http://DMGMORI.com/UA/OemExtensions/"
   ],
   "NamespaceInformations": [
     {
+      "Namespace": "http://DMGMORI.com/UA/OemExtensions/",
+      "Types": [
+        {
+          "Uri": "http://DMGMORI.com/UA/OemExtensions/",
+          "Id": "i=1003",
+          "BaseTypeLevel": 1,
+          "$comment": "DMGMORI_MachineToolType"
+        }
+      ],
+      "IdentificationType": {
+        "Uri": "http://opcfoundation.org/UA/MachineTool/",
+        "Id": "i=11",
+        "$comment": "MachineToolIdentificationType"
+      }
+    },
+    {
+      "Namespace": "http://opcfoundation.org/UA/Robotics/",
+      "Types": [
+        {
+          "Uri": "http://opcfoundation.org/UA/Robotics/",
+          "Id": "i=1004",
+          "BaseTypeLevel": 0,
+          "$comment": "MotionDeviceType"
+        },
+        {
+          "Uri": "http://opcfoundation.org/UA/Robotics/",
+          "Id": "i=1003",
+          "BaseTypeLevel": 0,
+          "$comment": "ControllerType"
+        }
+      ],
+      "IdentificationType": {
+        "Uri": "http://opcfoundation.org/UA/Machinery/",
+        "Id": "i=1012",
+        "$comment": "MachineIdentificationType"
+      }
+    },
+    {
+      "Namespace": "http://opcfoundation.org/UA/MachineTool-Prototyping/",
+      "Types": [
+        {
+          "Uri": "http://opcfoundation.org/UA/MachineTool-Prototyping/",
+          "Id": "i=1014",
+          "BaseTypeLevel": 0,
+          "$comment": "MachineToolType"
+        }
+      ],
+      "IdentificationType": {
+        "Uri": "http://opcfoundation.org/UA/MachineTool-Prototyping/",
+        "Id": "i=1012",
+        "$comment": "MachineToolIdentificationType"
+      }
+    },
+    {
       "Namespace": "http://opcfoundation.org/UA/MachineTool/",
-	    "Types": [
+      "Types": [
         {
           "Uri": "http://opcfoundation.org/UA/MachineTool/",
           "Id": "i=13",
+          "BaseTypeLevel": 0,
           "$comment": "MachineToolType"
         }
       ],
@@ -30,50 +88,73 @@
         "Uri": "http://opcfoundation.org/UA/MachineTool/",
         "Id": "i=11",
         "$comment": "MachineToolIdentificationType"
-
+      }
+    },
+    {
+      "Namespace": "http://opcfoundation.org/UA/Woodworking/",
+      "Types": [
+        {
+          "Uri": "http://opcfoundation.org/UA/Woodworking/",
+          "Id": "i=2",
+          "BaseTypeLevel": 0,
+          "$comment": "WwMachineType"
+        }
+      ],
+      "IdentificationType": {
+        "Uri": "http://opcfoundation.org/UA/Machinery/",
+        "Id": "i=1012",
+        "$comment": "MachineIdentificationType"
       }
     },
     {
       "Namespace": "http://opcfoundation.org/UA/SurfaceTechnology/",
-	    "Types": [
+      "Types": [
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1009",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologCoatingSystemType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1006",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTecnologyObjectType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1010",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyDosingSystemType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1011",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyFilterSystemType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1005",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyPipeType"
         },
-           {
+        {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1008",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyPumpType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1004",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyValveType"
         },
         {
           "Uri": "http://opcfoundation.org/UA/SurfaceTechnology/",
           "Id": "i=1003",
+          "BaseTypeLevel": 0,
           "$comment": "SurfaceTechnologyVesselType"
         }
       ],
@@ -82,9 +163,8 @@
         "Id": "i=1012",
         "$comment": "MachineIdentificationType"
       }
-    }    
-  ]
-  ,
+    }
+  ],
   "OpcUa": {
     "Endpoint": "opc.tcp://localhost:4840",
     "Username": "",


### PR DESCRIPTION
Some Manufacturers (like DMG) derive their own SubTypes from specified TypeDefintions, e.g.
DMGMori_MachineToolType has SuperType MachineToolType. As we don't want those "non official 
MachineTypes to be published under their own topic, the BaseTypeLevel-Config is introduced, which 
allows to specify, how far to go up in the HasSuperType references to the "real" MachineType.
Currently 0 or 1 layers are implemented.  