### PR TITLE
Enable certificate handling for MQTT TLS connections.

### DIFF
--- a/.github/CMakeLists.txt
+++ b/.github/CMakeLists.txt
@@ -109,6 +109,7 @@ externalproject_add(
 
 
 if(${BUILD_DEB_PACKAGE})
+    message("### Build debian package")
     unset(BINARY_DIR)
     ExternalProject_Get_property(Dashboard-Client BINARY_DIR) 
     set(BINARY_DIR_Dashboard-Client ${BINARY_DIR})   
@@ -121,7 +122,7 @@ if(${BUILD_DEB_PACKAGE})
     set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/../README.md")
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Marc Fischer")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6 (>= ${DEB_PACKAGE_LIBCPP_VERSION}), openssl(>= 1.1.1)")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6 (>= ${DEB_PACKAGE_LIBCPP_VERSION}), openssl(>= 1.1.1), ca-certificates")
     set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
     set(CPACK_DEB_COMPONENT_INSTALL YES)
     INCLUDE(CPack)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,11 @@ jobs:
         run: |
           cd build/Dashboard-Client-build
           ctest -V -C ${{matrix.build_type}}
+      - name: Download CA Certs
+        run: |
+          cd ${{ env.CMAKE_INSTALL_PREFIX }}
+          mkdir -p  bin/certs
+          curl https://curl.se/ca/cacert.pem -o bin/certs/cacert.pem -s
       - name: Upload Artefacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,17 +21,24 @@ jobs:
           submodules: recursive
       - name: Build UmatiDashboardOpcUaClient with dependencies
         run: |
-          LIBCPP_VERSION=$(dpkg -s libstdc++6 | grep Version | awk '{match($0,"[0-9]+.[0-9].[0-9]",a)}END{print a[0]}')
+          LIBCPP_VERSION="$(dpkg -s libstdc++6 | grep Version | awk '{match($0,"[0-9]+.[0-9].[0-9]",a)}END{print a[0]}')"
           mkdir -p build
           cd build
-          cmake ../UmatiDashboardOpcUaClient/.github/ -DCMAKE_INSTALL_PREFIX:PATH=${{ env.CMAKE_INSTALL_PREFIX }} \
-            -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPAHO_WITH_SSL=1 -DBUILD_DEB_PACKAGE:BOOL=1 -DDEB_PACKAGE_LIBCPP_VERSION=$LIBCPP_VERSION
+          cmake ../UmatiDashboardOpcUaClient/.github/ -DCMAKE_INSTALL_PREFIX:PATH="${{ env.CMAKE_INSTALL_PREFIX }}" \
+            -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -DPAHO_WITH_SSL=1 -DBUILD_DEB_PACKAGE:BOOL=1 -DDEB_PACKAGE_LIBCPP_VERSION="$LIBCPP_VERSION"
           cmake --build . -j
           make package
       - name: Run Tests
         run: |
           cd build/Dashboard-Client-build
-          ctest -V -C ${{matrix.build_type}}
+          ctest -V -C "${{matrix.build_type}}"
+      - name: Run integration test cacert_test
+        run : |
+          cd UmatiDashboardOpcUaClient/Tests/integration_tests/cacert_test
+          ./genCerts.sh
+          cp "${{ github.workspace }}/build/Dashboard-Client-build/Tests/TestCaCertificate" .
+          docker-compose up -d
+          ./evaluateTest.sh
       - name: Upload Artefacts
         uses: actions/upload-artifact@v3
         with:

--- a/DashboardOpcUaClient.cpp
+++ b/DashboardOpcUaClient.cpp
@@ -5,6 +5,7 @@
  * Copyright 2019-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  * Copyright 2020 (c) Dominik Basner, Sotec GmbH (for VDW e.V.)
  * Copyright 2021 (c) Marius Dege, basysKom GmbH
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #include "DashboardOpcUaClient.hpp"
@@ -26,8 +27,11 @@ m_pPublisher(std::make_shared<Umati::MqttPublisher_Paho::MqttPublisher_Paho>(
         configuration->getMqtt().Protocol,
         configuration->getMqtt().Hostname,
         configuration->getMqtt().Port,
+        configuration->getMqtt().CaCertPath,
+        configuration->getMqtt().CaTrustStorePath,
         configuration->getMqtt().Username,
-        configuration->getMqtt().Password)),
+        configuration->getMqtt().Password
+        )),
 m_pOpcUaTypeReader(std::make_shared<Umati::Dashboard::OpcUaTypeReader>(
         m_pClient,
         configuration->getObjectTypeNamespaces(),

--- a/MqttPublisher_Paho/MqttPublisher_Paho.cpp
+++ b/MqttPublisher_Paho/MqttPublisher_Paho.cpp
@@ -4,6 +4,7 @@
  * 
  * Copyright 2019-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  * Copyright 2020 (c) Dominik Basner, Sotec GmbH (for VDW e.V.)
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #include "MqttPublisher_Paho.hpp"
@@ -14,8 +15,8 @@
 namespace Umati {
 	namespace MqttPublisher_Paho {
 
-		MqttPublisher_Paho::MqttPublisher_Paho(const std::string &protocol, const std::string &host, std::uint16_t port, const std::string &username,
-											   const std::string &password)
+		MqttPublisher_Paho::MqttPublisher_Paho(const std::string &protocol, const std::string &host, std::uint16_t port, const std::string &CaCertPath,
+											   const std::string &CaTrustStorePath, const std::string &username, const std::string &password)
 				: m_cli(getUri(protocol, host, port), getClientId(), 0, nullptr), m_callbacks(this) {
 			m_cli.set_callback(m_callbacks);
 
@@ -23,12 +24,8 @@ namespace Umati {
 
 			if (protocol == "wss") {
 				mqtt::ssl_options ssl_opts;
-#ifndef WIN32
-				ssl_opts.ca_path("/etc/ssl/certs/");
-#else
-				ssl_opts.set_ca_path("./certs");
-				ssl_opts.set_trust_store("./certs/ca-certificates.crt");
-#endif
+				ssl_opts.ca_path(CaCertPath);
+				ssl_opts.set_trust_store(CaTrustStorePath);
 				ssl_opts.set_verify(true);
 				opts_conn.set_ssl(ssl_opts);
 			}

--- a/MqttPublisher_Paho/MqttPublisher_Paho.hpp
+++ b/MqttPublisher_Paho/MqttPublisher_Paho.hpp
@@ -4,6 +4,7 @@
  * 
  * Copyright 2019-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  * Copyright 2020 (c) Dominik Basner, Sotec GmbH (for VDW e.V.)
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #pragma once
@@ -29,6 +30,8 @@ namespace Umati {
 					const std::string &protocol,
 					const std::string &host,
 					std::uint16_t port,
+					const std::string &CaCertPath,
+					const std::string &CaTrustStorePath,
 					const std::string &username = std::string(),
 					const std::string &password = std::string()
 			);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -45,3 +45,7 @@ foreach(file_iterator ${CONFIG_TESTFILES})
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endforeach(file_iterator)
+
+
+add_executable(TestCaCertificate TestCaCertificate.cpp)
+target_link_libraries(TestCaCertificate Util GTest::gtest_main MqttPublisher_Paho MachineObserver)

--- a/Tests/TestCaCertificate.cpp
+++ b/Tests/TestCaCertificate.cpp
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
+ */
+
+#include <gtest/gtest.h>
+#include <Configuration.hpp>
+#include <ConfigurationJsonFile.hpp>
+#include <Exceptions/ConfigurationException.hpp>
+#include <MqttPublisher_Paho.hpp>
+#include <ConfigureLogger.hpp>
+
+TEST(OpcUaClient, CaCertificateLinux_SSLCerts) {
+  // Test the CaCertPath pointing to /etc/ssl/certs
+  Umati::Util::ConfigureLogger("DashboardOpcUaClient");
+  Umati::Util::ConfigurationJsonFile conf("ConfigurationCa.json");
+
+    EXPECT_NO_THROW(Umati::MqttPublisher_Paho::MqttPublisher_Paho publisher(
+    conf.getMqtt().Protocol,
+    conf.getMqtt().Hostname,
+    conf.getMqtt().Port,
+    conf.getMqtt().CaCertPath,
+    conf.getMqtt().CaTrustStorePath,
+    conf.getMqtt().Username,
+    conf.getMqtt().Password));
+}
+TEST(OpcUaClient, CaCertificateLinux_CurlCerts) {
+  // Test the CaTrustStorePath pointing to downloaded cacert.pem
+  Umati::Util::ConfigureLogger("DashboardOpcUaClient");
+  Umati::Util::ConfigurationJsonFile conf("ConfigurationCa2.json");
+
+  EXPECT_NO_THROW(Umati::MqttPublisher_Paho::MqttPublisher_Paho publisher(
+    conf.getMqtt().Protocol,
+    conf.getMqtt().Hostname,
+    conf.getMqtt().Port,
+    conf.getMqtt().CaCertPath,
+    conf.getMqtt().CaTrustStorePath,
+    conf.getMqtt().Username,
+    conf.getMqtt().Password));
+}

--- a/Tests/integration_tests/cacert_test/.gitignore
+++ b/Tests/integration_tests/cacert_test/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitignore
+!ConfigureCa.json
+!ConfigureCa2.json
+!docker-compose.yml
+!genCerts.sh
+!mosquitto.conf
+!test_entrypoint.sh
+!evaluateTest.sh

--- a/Tests/integration_tests/cacert_test/ConfigurationCa.json
+++ b/Tests/integration_tests/cacert_test/ConfigurationCa.json
@@ -1,0 +1,15 @@
+{
+  "Mqtt": {
+    "Hostname": "mqtt",
+    "Protocol": "wss",
+    "Port": 1884,
+    "Username": "",
+    "Password": "",
+    "CaCertPath":"/etc/ssl/certs",
+    "CaTrustStorePath": ""
+  },
+  "OpcUa": {},
+  "ObjectTypeNamespaces": [],
+  "NamespaceInformations": [],
+  "MachinesFilter": []
+}

--- a/Tests/integration_tests/cacert_test/ConfigurationCa2.json
+++ b/Tests/integration_tests/cacert_test/ConfigurationCa2.json
@@ -1,0 +1,15 @@
+{
+  "Mqtt": {
+    "Hostname": "mqtt",
+    "Protocol": "wss",
+    "Port": 1884,
+    "Username": "",
+    "Password": "",
+    "CaCertPath":"",
+    "CaTrustStorePath": "./ca.crt"
+  },
+  "OpcUa": {},
+  "ObjectTypeNamespaces": [],
+  "NamespaceInformations": [],
+  "MachinesFilter": []
+}

--- a/Tests/integration_tests/cacert_test/docker-compose.yml
+++ b/Tests/integration_tests/cacert_test/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: '3.1'
+services:
+  mqtt:
+    image: eclipse-mosquitto
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ./certs_server:/mosquitto/certs
+  test:
+    image: ubuntu:22.04
+    depends_on:
+      - mqtt
+    volumes:
+      - ./TestCaCertificate:/app/TestCaCertificate
+      - ./ConfigurationCa.json:/app/ConfigurationCa.json
+      - ./ConfigurationCa2.json:/app/ConfigurationCa2.json
+      - ./test_entrypoint.sh:/app/test_entrypoint.sh
+      - ./certs/ca.crt:/app/ca.crt
+    entrypoint: ["/app/test_entrypoint.sh"]

--- a/Tests/integration_tests/cacert_test/evaluateTest.sh
+++ b/Tests/integration_tests/cacert_test/evaluateTest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+NEXT_WAITTIME=0
+WAITTIME_LIMIT_SEC=120
+while [[ "$(docker inspect  cacert_test_test_1 --format='{{.State.Status}}')" != "exited" || "$NEXT_WAITTIME" == "$WAITTIME_LIMIT_SEC" ]]
+do 
+    echo "Waiting for test container to become ready since ${NEXT_WAITTIME}s..."
+    sleep 1
+    NEXT_WAITTIME=$(($NEXT_WAITTIME+1))
+done
+docker-compose logs
+exit "$(docker inspect  cacert_test_test_1 --format='{{.State.ExitCode}}')"

--- a/Tests/integration_tests/cacert_test/genCerts.sh
+++ b/Tests/integration_tests/cacert_test/genCerts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+rm -r -f certs
+mkdir -p certs
+rm -r -f certs_server
+mkdir -p certs_server
+# Generate root CA
+openssl req  -nodes -new -x509  -keyout certs/ca.key -out certs/ca.crt -subj "/C=DE/O=UmatiApp/OU=DevOps"
+# Generate Server cert
+openssl genrsa -out certs_server/server.key 2048
+openssl req -new -key certs_server/server.key -out certs_server/server.csr  -subj "/C=DE/O=UmatiApp/OU=DevOps/CN=mqtt"
+openssl x509 -req -in certs_server/server.csr -CA certs/ca.crt -CAkey certs/ca.key -CAcreateserial -out certs_server/server.crt -days 365 -sha256
+
+cp certs/ca.crt certs_server

--- a/Tests/integration_tests/cacert_test/mosquitto.conf
+++ b/Tests/integration_tests/cacert_test/mosquitto.conf
@@ -1,0 +1,15 @@
+listener 1883
+protocol mqtt
+
+log_dest stdout
+log_type all
+
+allow_anonymous true
+
+
+listener 1884
+protocol websockets
+
+cafile /mosquitto/certs/ca.crt
+certfile /mosquitto/certs/server.crt
+keyfile /mosquitto/certs/server.key

--- a/Tests/integration_tests/cacert_test/test_entrypoint.sh
+++ b/Tests/integration_tests/cacert_test/test_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd /app || exit
+apt update && apt install -y openssl
+# Copy cert and hash folder for test case CaCertificateLinux_SSLCerts
+mkdir -p /etc/ssl/certs/
+cp ca.crt /etc/ssl/certs/
+openssl rehash -compat -v /etc/ssl/certs/
+# Execute Tests
+./TestCaCertificate

--- a/Util/Configuration.hpp
+++ b/Util/Configuration.hpp
@@ -4,6 +4,7 @@
  *
  * Copyright 2019-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  * Copyright 2020 (c) Dominik Basner, Sotec GmbH (for VDW e.V.)
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #pragma once
@@ -26,6 +27,12 @@ namespace Umati {
 			std::string Prefix = "umati";
 			std::string ClientId = "umati";
 			std::string Protocol = "tcp";
+			std::string CaTrustStorePath = "./certs/cacert.pem";
+#ifndef WIN32
+			std::string CaCertPath = "/etc/ssl/certs/";
+#else
+			std::string CaCertPath = "./certs";
+#endif
 		};
 
 		struct OpcUaConfig {

--- a/Util/ConfigurationJsonFile.hpp
+++ b/Util/ConfigurationJsonFile.hpp
@@ -4,6 +4,7 @@
  * 
  * Copyright 2019-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  * Copyright 2020 (c) Dominik Basner, Sotec GmbH (for VDW e.V.)
+ * Copyright 2023 (c) Marc Fischer, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 #pragma once
 
@@ -17,7 +18,7 @@ namespace ModelOpcUa
 }
 namespace Umati {
 	namespace Util {
-		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(MqttConfig, Hostname, Port, Username, Password, Prefix, ClientId, Protocol);
+		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(MqttConfig, Hostname, Port, Username, Password, Prefix, ClientId, Protocol, CaCertPath, CaTrustStorePath);
 		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(OpcUaConfig, Endpoint, Username, Password, Security, ByPassCertVerification);
 		NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(NamespaceInformation, Namespace, Types, IdentificationType);
 


### PR DESCRIPTION
Enable certificate handling for MQTT TLS connections. Fully resolves issue #311. Partially resolves issues #309 and #310.

- Add mqtt configuration options for CA certificate path
  - Default for mqtt.CaTrustStorePath="./certs".
  - Default for mqtt.CaCertPath="/etc/ssl/certs/" for Linux and "./certs" for Windows
- Add tests against dev.umati.app for testing secure connections
- Add requirements to the ca-certificates Debian package
- Add CA certificates to the Windows artifacts from https://curl.se/docs/caextract.html

