### PR TITLE
Fix architecture for win build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,12 @@ jobs:
           submodules: recursive
       - name: Build UmatiDashboardOpcUaClient with dependencies
         run: |
+          $matrixarch = "${{matrix.arch}}"
+          if($matrixarch = "386"){$arch="Win32"}
+          if($matrixarch = "amd64"){$arch="x64"}
           mkdir -p build
           cd build
-          cmake ../UmatiDashboardOpcUaClient/.github/ -DCMAKE_INSTALL_PREFIX:PATH=${{ env.CMAKE_INSTALL_PREFIX }} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPAHO_WITH_SSL=1
+          cmake ../UmatiDashboardOpcUaClient/.github/ -DCMAKE_INSTALL_PREFIX:PATH=${{ env.CMAKE_INSTALL_PREFIX }} -A "$arch" -DPAHO_WITH_SSL=1
           cmake --build . -j --config ${{matrix.build_type}}
       - name: Run Tests
         run: |


### PR DESCRIPTION
The Windows artifacts now support x86 and x64. This completely fixes #309 and #310.
To run on Windows, only the Visual C++ Redistributable package is required, which can be downloaded [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170). It is possible to extract the required DLLs with [WiX Toolset](https://github.com/wixtoolset/wix3) and [expand](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/expand) and deploy them separately if installer privileges are not available on a target system.

Tested systems are:
  * Win7 32bit
  * Win7 64bit
  * Win11 64bit