### PR TITLE
improve fetching git information in ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-**/.git
+deps/**/.git
 Dockerfile
 .dockerignore
 docker-compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           path: UmatiDashboardOpcUaClient
           submodules: recursive
+          fetch-depth: 0
       - name: Build UmatiDashboardOpcUaClient with dependencies
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           path: UmatiDashboardOpcUaClient
           submodules: recursive
+          fetch-depth: 0
       - name: Build UmatiDashboardOpcUaClient with dependencies
         shell: pwsh
         # yamllint disable rule:line-length
@@ -122,6 +123,7 @@ jobs:
         with:
           path: UmatiDashboardOpcUaClient
           submodules: recursive
+          fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
       - name: Set up Docker Buildx

--- a/cmake/SetGitBasedVersion.cmake
+++ b/cmake/SetGitBasedVersion.cmake
@@ -8,7 +8,7 @@ function(set_umati_dashboard_client_version)
     # Generate a git-describe version string from Git repository tags
     if(GIT_EXECUTABLE AND NOT DEFINED UMATI_CLIENT_VERSION)
         execute_process(
-            COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+            COMMAND ${GIT_EXECUTABLE} describe --always --tags --dirty --match "v*"
             WORKING_DIRECTORY "${VERSION_SRC_DIR}"
             OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
             RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE


### PR DESCRIPTION
Seems to work now:
https://github.com/umati/Dashboard-OPCUA-Client/actions/runs/4830139197/jobs/8605994456#step:3:3160

The problem was that the ci only fetch the last commit not the tags. 
Current solution works with fetch-deeps:0 (all)

I´m  not sure if a small group is enough and I found no other configuration 
@ccvca What do you think? 